### PR TITLE
Remove root vercel.json (conflicts with Vercel Root Directory=frontend)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "buildCommand": "cd frontend && pnpm run build",
-  "outputDirectory": "frontend/.next",
-  "installCommand": "pnpm install",
-  "framework": "nextjs"
-}


### PR DESCRIPTION
The 'cd frontend && pnpm run build' build command double-cd's when the Vercel project Root Directory is set to 'frontend', causing:
  sh: line 1: cd: frontend: No such file or directory
With Root Directory=frontend, Vercel auto-detects the Next app and needs no custom build/output commands.